### PR TITLE
ci: trigger discourse-image rebuild on push

### DIFF
--- a/.github/workflows/dispatch-image-build.yml
+++ b/.github/workflows/dispatch-image-build.yml
@@ -1,0 +1,17 @@
+name: dispatch image build
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.IMAGE_BUILD_PAT }}
+          repository: vzekc/discourse-image
+          event-type: plugin-updated
+          client-payload: |
+            {"source": "${{ github.repository }}", "sha": "${{ github.sha }}"}


### PR DESCRIPTION
## Summary
- Adds a workflow that fires `repository_dispatch` at `vzekc/discourse-image` whenever this plugin's `main` branch is updated.
- Lets the cluster pick up plugin changes within minutes instead of waiting for the daily 04:00 UTC cron rebuild.

## Required follow-up
Add a repository secret `IMAGE_BUILD_PAT`:
- Fine-scoped PAT (or GitHub App token) with **Actions: write** access on `vzekc/discourse-image`.
- Without it, the workflow will fail with a 401 on every push to `main`.

## Test plan
- [ ] Add the `IMAGE_BUILD_PAT` secret
- [ ] Merge this PR
- [ ] Push a no-op commit to `main` and confirm `vzekc/discourse-image` shows a new build run triggered by `plugin-updated`