### PR TITLE
Fix 404 on user lottery routes for usernames containing a dot

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@
 VzekcVerlosung::Engine.routes.draw do
   get "/has-new-content" => "new_content#index"
   get "/examples" => "examples#index"
-  get "/users/:username" => "user_stats#show"
+  get "/users/:username" => "user_stats#show", :constraints => { username: RouteFormat.username }
   get "/history" => "lottery_history#index"
   get "/history/stats" => "lottery_history#stats"
   get "/history/leaderboard" => "lottery_history#leaderboard"
@@ -75,7 +75,10 @@ VzekcVerlosung::Engine.routes.draw do
 
   # Notification logs routes
   get "/admin/notification-logs" => "notification_logs#admin_index"
-  get "/users/:username/notification-logs" => "notification_logs#user_index"
+  get "/users/:username/notification-logs" => "notification_logs#user_index",
+      :constraints => {
+        username: RouteFormat.username,
+      }
 end
 
 Discourse::Application.routes.draw do

--- a/spec/requests/vzekc_verlosung/notification_logs_controller_spec.rb
+++ b/spec/requests/vzekc_verlosung/notification_logs_controller_spec.rb
@@ -254,5 +254,16 @@ RSpec.describe VzekcVerlosung::NotificationLogsController do
         expect(response.status).to eq(404)
       end
     end
+
+    context "with a username containing a dot" do
+      fab!(:dotted_user) { Fabricate(:user, username: "Olaf.Friedrich") }
+
+      before { sign_in(dotted_user) }
+
+      it "returns the notification logs" do
+        get "/vzekc-verlosung/users/#{dotted_user.username}/notification-logs.json"
+        expect(response.status).to eq(200)
+      end
+    end
   end
 end

--- a/spec/requests/vzekc_verlosung/user_stats_controller_spec.rb
+++ b/spec/requests/vzekc_verlosung/user_stats_controller_spec.rb
@@ -34,6 +34,18 @@ RSpec.describe VzekcVerlosung::UserStatsController do
       end
     end
 
+    context "with a username containing a dot" do
+      fab!(:dotted_user) { Fabricate(:user, username: "Olaf.Friedrich") }
+
+      it "returns user stats" do
+        get "/vzekc-verlosung/users/#{dotted_user.username}.json"
+        expect(response.status).to eq(200)
+
+        json = response.parsed_body
+        expect(json).to have_key("won_packets")
+      end
+    end
+
     context "with lottery data" do
       fab!(:lottery_topic) { Fabricate(:topic, category: lottery_category, user: user) }
       fab!(:lottery) do


### PR DESCRIPTION
## Problem

`olaf.friedrich` (and 98 other users with a dot in their username) saw an empty **Meine Gewinne** page despite having won packets.

The `/users/:username` and `/users/:username/notification-logs` engine routes used Rails' default route-segment constraint (`[^/.?]+`), which excludes dots. `GET /vzekc-verlosung/users/Olaf.Friedrich.json` matched no route and returned a 404 Routing Error. The frontend's `loadData()` swallows the error, so the won-packets tab silently fell through to its empty state.

Verified live: before the fix `/vzekc-verlosung/users/Olaf.Friedrich.json` → 404, `/vzekc-verlosung/users/Olaf.json` → 200. After the fix the dotted username returns 200 with all 12 won packets.

## Fix

Added `constraints: { username: RouteFormat.username }` to both `:username` routes — the same regex (`/[%\w.\-]+?/`) Discourse core uses for its own `/u/:username` routes. It permits dots, hyphens, and percent-encoding (forward-compatible with `unicode_usernames`).

## Tests

Added a context to `user_stats_controller_spec.rb` and `notification_logs_controller_spec.rb` that fabricates a user named `Olaf.Friedrich` and asserts the endpoint returns 200. The user-stats test was confirmed to fail (404) before the fix. All 24 examples in the two specs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)